### PR TITLE
ATB-1166 | Establish an ais-infra-alerting stack

### DIFF
--- a/ais-infra-alerting/README.md
+++ b/ais-infra-alerting/README.md
@@ -1,0 +1,41 @@
+# Account Interventions Service - AIS Infra Alerting
+
+## Intro
+Consolidated alerting functionality to create a general infra alerting template with a subscription endpoint for PagerDuty and a single Chatbot configuration for all Slack alerts relating to AIS.
+
+## Prerequisites
+Export credentials for the AWS account where you want to deploy the application.
+You can use the following command to export credentials into your shell:
+```bash
+eval $(gds aws di-id-reuse-core-<environment>-admin -e)
+```
+Replace `<environment>` with the environment you are deploying into.
+Allowed values are `build`, `staging`, `integration`, `production`.
+
+## How to Deploy
+To deploy this SAM template, follow these steps:
+1. Navigate to the `ais-infra-alerting` directory
+2. Build the SAM application:
+```bash
+sam build
+```
+3. Deploy the application to your AWS account:
+```bash
+sam deploy --guided
+```
+The `--guided` flag will prompt you to input the necessary parameters for the deployment, such as the stack name, region, and environment.
+
+For the Parameter `InitialNotificationStack` select `No` in `build` and `staging` env because this is not the first time that we will be deploying 
+a infra-alerting stack, and therefore would not need to create these two Service Linked Roles `AWSServiceRoleForCodeStarNotifications` & `AWSServiceRoleForAWSChatbot` again. 
+However, in `integration` and `production` env would need to change over the parameter value to `Yes` as these two service linked roles have not yet been created in the account. 
+
+After the deployment is complete, you can check the CloudFormation stack status in the AWS Management Console or by using the AWS CLI:
+```bash
+aws cloudformation describe-stacks --stack-name ais-infra-alerting --region eu-west-2
+```
+
+
+### Stack Outputs
+| Type           | Name                                                      | Description                                                                                                                        |
+|----------------|-----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| SNS Topic      | `<environment>-BuildNotificationTopicArn`                 | ARN of the pipeline build notification SNS topic                                                                                   |

--- a/ais-infra-alerting/README.md
+++ b/ais-infra-alerting/README.md
@@ -36,9 +36,9 @@ sam deploy --guided
 ```
 The `--guided` flag will prompt you to input the necessary parameters for the deployment, such as the stack name, region, and environment.
 
-For the Parameter `InitialNotificationStack` select `No` in `build` and `staging` env because this is not the first time that we will be deploying 
-a infra-alerting stack, and therefore would not need to create these two Service Linked Roles `AWSServiceRoleForCodeStarNotifications` & `AWSServiceRoleForAWSChatbot` again. 
-However, in `integration` and `production` env would need to change over the parameter value to `Yes` as these two service linked roles have not yet been created in the account. 
+For the Parameter `InitialNotificationStack` select `No` in all environments when deploying the stack infra-alerting stack, 
+we would not need to create these two Service Linked Roles `AWSServiceRoleForCodeStarNotifications` & `AWSServiceRoleForAWSChatbot`
+as they have already been created in the accounts. 
 
 After the deployment is complete, you can check the CloudFormation stack status in the AWS Management Console or by using the AWS CLI:
 ```bash

--- a/ais-infra-alerting/README.md
+++ b/ais-infra-alerting/README.md
@@ -10,7 +10,7 @@ You can use the following command to export credentials into your shell:
 eval $(gds aws di-id-reuse-core-<environment>-admin -e)
 ```
 Replace `<environment>` with the environment you are deploying to, in this instance for `di-id-reuse-core` AWS accounts
-Allowed values are `build` and `staging` 
+Allowed values are `dev` `build` and `staging` 
 
 Whereas to deploy to `integration` and  `production` you'd need to Login into the Account Interventions Service AWS accounts using sso 
 

--- a/ais-infra-alerting/README.md
+++ b/ais-infra-alerting/README.md
@@ -9,8 +9,19 @@ You can use the following command to export credentials into your shell:
 ```bash
 eval $(gds aws di-id-reuse-core-<environment>-admin -e)
 ```
-Replace `<environment>` with the environment you are deploying into.
-Allowed values are `build`, `staging`, `integration`, `production`.
+Replace `<environment>` with the environment you are deploying to, in this instance for `di-id-reuse-core` AWS accounts
+Allowed values are `build` and `staging` 
+
+Whereas to deploy to `integration` and  `production` you'd need to Login into the Account Interventions Service AWS accounts using sso 
+
+`Integration`: 
+```bash
+aws sso login --profile di-account-intervention-admin-217747075921
+```
+`Production`: 
+```bash
+aws sso login --profile di-account-intervention-admin-324281879537
+```
 
 ## How to Deploy
 To deploy this SAM template, follow these steps:

--- a/ais-infra-alerting/samconfig.toml
+++ b/ais-infra-alerting/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "ais-infra-alerting"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-44r43ey3knwx"
+s3_prefix = "ais-infra-alerting"
+region = "eu-west-2"
+capabilities = "CAPABILITY_NAMED_IAM"
+image_repositories = []
+parameter_overrides = "Environment=\"build\""

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -1,0 +1,393 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: >-
+  This stack sets up the resources required for AIS alerting
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  ProductTagValue:
+    Description: Value for the Product Tag
+    Type: String
+    Default: GOV.UK One Login
+  OwnerTagValue:
+    Description: Value for the Owner Tag
+    Type: String
+    Default: PLACEHOLDER
+  SourceTagValue:
+    Description: Value for the Source Tag
+    Type: String
+    Default: govuk-one-login/ais-infra/ais-infra-alerting/template.yaml
+  SystemTagValue:
+    Description: Value for the System Tag
+    Type: String
+    Default: Account Interventions Service
+  SlackWorkspaceId:
+    Description: >
+      The ID of the Slack workspace where alert notification messages are
+      posted. This is retrieved from the AWS Chatbot integration.
+    Type: String
+    Default: "T8GT9416G"
+    AllowedPattern: "\\w+"
+    ConstraintDescription: "must be an AWS Chatbot Slack workspace ID"
+  SlackChannelId:
+    Description: >
+      The ID of the Slack channel where alert notification messages are posted.
+      This is taken from the channel details in Slack.
+      Default is the di-accounts-bravo-ais-notifications channel.
+    Type: String
+    Default: "C065MT3RKV4"
+    AllowedPattern: "\\w+"
+    ConstraintDescription: "must be a Slack channel ID"
+  SubscriptionEndpoint:
+    Description: >
+      External API subscription endpoint i.e. PagerDuty events integration API
+    Type: String
+    Default: "none"
+    AllowedPattern: "(^https://.+)|(none)"
+    ConstraintDescription: "Must be a URL of format (https://.*) or leave as 'none'"
+  InitialNotificationStack:
+    Description: >
+      (Optional) Is this the first notification stack to be created in this account?
+    Type: String
+    Default: "No"
+    AllowedValues:
+      - "Yes"
+      - "No"
+
+Conditions:
+  CreateSNSSubscription:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref SubscriptionEndpoint
+          - "none"
+  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ] ]
+  IsInternal: !Or [ !Equals [ !Ref Environment, dev ], !Equals [ !Ref Environment, build ],!Equals [ !Ref Environment, staging ] ]
+  IsDeployServiceLinkedRoles:
+    Fn::Equals:
+      - !Ref InitialNotificationStack
+      - "Yes"
+  IsServiceLinkRoleRequired: !And
+    - !Condition IsNotDevelopment
+    - !Condition IsDeployServiceLinkedRoles
+
+Resources:
+  #
+  # CloudWatch Alert High Severity SNS Topic
+  #
+
+  HighAlertNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${AWS::StackName}-HighAlertNotificationTopic"
+      KmsMasterKeyId: !Ref NotificationTopicKey
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-HighAlertNotificationTopic"
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  HighAlertNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref HighAlertNotificationTopic
+      PolicyDocument:
+        Statement:
+          - Sid: AllowCloudWatchAlarmsToPublishToSNS
+            Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref HighAlertNotificationTopic
+            Principal:
+              Service: cloudwatch.amazonaws.com
+
+  #
+  # CloudWatch Alert Low Severity SNS Topic
+  #
+
+  LowAlertNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${AWS::StackName}-LowAlertNotificationTopic"
+      KmsMasterKeyId: !Ref NotificationTopicKey
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-LowAlertNotificationTopic"
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  LowAlertNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref LowAlertNotificationTopic
+      PolicyDocument:
+        Statement:
+          - Sid: AllowCloudWatchAlarmsToPublishToSNS
+            Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref LowAlertNotificationTopic
+            Principal:
+              Service: cloudwatch.amazonaws.com
+
+  #
+  # Pipeline Build SNS Topic
+  #
+
+  BuildNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${AWS::StackName}-BuildNotificationTopic"
+      KmsMasterKeyId: !Ref NotificationTopicKey
+      Tags:
+        - Key: Name
+          Value: !Join
+            - "-"
+            - - !Ref AWS::StackName
+              - "BuildNotificationTopic"
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  BuildNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref BuildNotificationTopic
+      PolicyDocument:
+        Statement:
+          - Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref BuildNotificationTopic
+            Principal:
+              Service: codestar-notifications.amazonaws.com
+
+  #
+  # Shared SNS KMS Key
+  #
+
+  NotificationTopicKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: "Allow the account to manage the key"
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: "Allow CodeStar Notifications to enqueue encrypted messages"
+            Effect: Allow
+            Resource: "*"
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey"
+            Principal:
+              Service: codestar-notifications.amazonaws.com
+          - Sid: "Allow Cloudwatch alerts access"
+            Effect: Allow
+            Principal:
+              Service: cloudwatch.amazonaws.com
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource:
+              - "*"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-NotificationTopicKey"
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  #
+  # Slack Chatbot Integration
+  #
+
+  ChatbotRole:
+    Condition: IsNotDevelopment
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "chatbot.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: !Sub "${AWS::StackName}-ChatBotPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: "DescribeLogs"
+                Effect: "Allow"
+                Action:
+                  - "logs:DescribeQueryDefinitions"
+                  - "logs:DescribeMetricFilters"
+                  - "logs:DescribeLogGroups"
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group::log-stream:*"
+      Tags:
+        - Key: Name
+          Value: !Join
+            - "-"
+            - - !Ref AWS::StackName
+              - "ChatbotRole"
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  ChatbotChannelConfiguration:
+    Condition: IsNotDevelopment
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Properties:
+      ConfigurationName: !Sub "${AWS::StackName}-slack-notifications"
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackChannelId: !Ref SlackChannelId
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SnsTopicArns:
+        - !Ref HighAlertNotificationTopic
+        - !Ref LowAlertNotificationTopic
+        - !Ref BuildNotificationTopic
+
+  CodeStarNotificationsServiceLinkedRole:
+    Condition: IsServiceLinkRoleRequired
+    Type: AWS::IAM::ServiceLinkedRole
+    DeletionPolicy: Retain
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3011  # The UpdateReplacePolicy does not apply to this resource
+    Properties:
+      AWSServiceName: codestar-notifications.amazonaws.com
+
+  ChatbotServiceLinkedRole:
+    Condition: IsServiceLinkRoleRequired
+    Type: AWS::IAM::ServiceLinkedRole
+    DeletionPolicy: Retain
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3011  # The UpdateReplacePolicy does not apply to this resource
+    Properties:
+      AWSServiceName: management.chatbot.amazonaws.com
+
+  #
+  # PagerDuty Integration
+  #
+
+  AlertNotificationTopicSubscription:
+    Condition: CreateSNSSubscription
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Ref SubscriptionEndpoint
+      Protocol: 'https'
+      TopicArn: !Ref HighAlertNotificationTopic
+
+  #
+  # SSM Parameter
+  #
+
+  HighAlertNotificationTopicArnSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ARN of the High Alert Notification SNS Topic used for Alert actions
+      Name: !Sub "/${AWS::StackName}/SNS/HighAlertNotificationTopic/ARN"
+      Type: String
+      Value: !Ref HighAlertNotificationTopic
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
+  LowAlertNotificationTopicArnSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ARN of the Low Alert Notification SNS Topic used for Alert actions
+      Name: !Sub "/${AWS::StackName}/SNS/LowAlertNotificationTopic/ARN"
+      Type: String
+      Value: !Ref LowAlertNotificationTopic
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
+  BuildNotificationTopicArnSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ARN of the Build Notification SNS Topic used for Alert actions
+      Name: !Sub "/${AWS::StackName}/SNS/BuildNotificationTopic/ARN"
+      Type: String
+      Value: !Ref BuildNotificationTopic
+      Tags:
+        Environment: !Ref Environment
+        Product: !Ref ProductTagValue
+        System: !Ref SystemTagValue
+        Owner: !Ref OwnerTagValue
+        Source: !Ref SourceTagValue
+
+Outputs:
+  BuildNotificationTopicArn:
+    Description: >
+      The ARN of the SNS topic that receives CodePipeline build notifications that gets sent to Slack.
+    Value: !Ref BuildNotificationTopic
+    Export:
+      Name: !Sub "${AWS::StackName}-BuildNotificationTopicArn"

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -44,7 +44,7 @@ Parameters:
       This is taken from the channel details in Slack.
       Default is the di-accounts-bravo-ais-notifications channel.
     Type: String
-    Default: "C065MT3RKV4"
+    Default: "C065MT3RKV4" # di-accounts-bravo-ais-notifications
     AllowedPattern: "\\w+"
     ConstraintDescription: "must be a Slack channel ID"
   SubscriptionEndpoint:


### PR DESCRIPTION
### What? 
Created a `ais-infra-alerting` stack includes: 
3 SNS Topics - P1/2 incidents, P3/4 incidents and build notifications
SlackBot configuration
Pager Duty Integration
SSM Parameters

### Why? 
To have the correct alerting infrastructure in place for AIS for p1-p2 incidents to be directed to our Pager Duty endpoint and P3-4 to our slack channel - `di-accounts-bravo-ais-notifications ` along with our build-notification alerts for our secure pipeline failures. 

### Testing 
In Build env 
![Screenshot 2023-11-15 at 13 08 36](https://github.com/govuk-one-login/ais-infra/assets/116737136/cb5303e9-dbcf-4adb-89a6-cf6cd02ed368)
