### PR TITLE
ATB 1206 | Create a infra-common template for Dynatrace api token 

### DIFF
--- a/ais-infra-common/README.md
+++ b/ais-infra-common/README.md
@@ -1,0 +1,44 @@
+# Account Interventions Service - AIS Infra Common 
+
+## Intro
+Externalise values referenced across multiple CloudFormation Stacks.
+This prevents having to individually update each reference of a single value across multiple Stacks.
+Values will instead resolve as SSM parameters or Secrets acting as the single source of truth.
+
+## Prerequisites
+Export credentials for the AWS account where you want to deploy the application. 
+You can use the following command to export credentials into your shell:
+```bash
+eval $(gds aws di-id-reuse-core-<environment>-admin -e)
+```
+Replace `<environment>` with the environment you are deploying into.
+Allowed values are `dev`, `build`, `staging`.
+
+Whereas to deploy to `integration` and  `production` you'd need to Login into the Account Interventions Service AWS accounts using sso
+
+`Integration`:
+```bash
+aws sso login --profile di-account-intervention-admin-217747075921
+```
+`Production`:
+```bash
+aws sso login --profile di-account-intervention-admin-324281879537
+```
+
+## How to Deploy
+To deploy this SAM template, follow these steps:
+1. Navigate to the `ais-infra-common` directory
+2. Build the SAM application:
+```bash
+sam build
+```
+3. Deploy the application to your AWS account:
+```bash
+sam deploy --guided
+```
+The `--guided` flag will prompt you to input the necessary parameters for the deployment, such as the stack name, region, and environment.
+
+After the deployment is complete, you can check the CloudFormation stack status in the AWS Management Console or by using the AWS CLI:
+```bash
+aws cloudformation describe-stacks --stack-name ais-infra-common --region eu-west-2
+```

--- a/ais-infra-common/samconfig.toml
+++ b/ais-infra-common/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "ais-infra-common"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-44r43ey3knwx"
+s3_prefix = "ais-infra-common"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+image_repositories = []
+parameter_overrides = "Environment=\"dev\""

--- a/ais-infra-common/template.yaml
+++ b/ais-infra-common/template.yaml
@@ -1,0 +1,62 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: >
+  Externalises values referenced across multiple CloudFormation Stacks.
+  This prevents having to individually update each reference of a single value across multiple stacks or resources.
+  Values will instead resolve as SSM parameters or Secrets acting as the single source of truth.
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    Default: dev
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  ProductTagValue:
+    Description: Value for the Product Tag
+    Type: String
+    Default: GOV.UK One Login
+  SystemTagValue:
+    Description: Value for the System Tag
+    Type: String
+    Default: Account Interventions Service
+  OwnerTagValue:
+    Description: Value for the Owner Tag
+    Type: String
+    Default: PLACEHOLDER
+  SourceTagValue:
+    Description: Value for the Source Tag
+    Type: String
+    Default: govuk-one-login/ais-infra/ais-infra-common/template.yaml
+
+Resources:
+
+  ###########
+  # SECRETS #
+  ###########
+
+  # see https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3660317070/How+to+add+secure+pipelines+metrics+to+Dynatrace
+  DynatraceApiToken:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: "dynatrace-api-token"
+      Description: "Dynatrace API token"
+      SecretString: "dt0c01.ESVFDCGJZEL6W7WUTCGKZAQN.QUFK5TZVRP3RNV4AAANE4MYXZIXVXWGRG2BHHU3WONNNM5EQERYZFKXFMQFGCGOJ" # uses the default aws/secretsmanager key to encrypt the secret string
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynatraceApiToken"
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue

--- a/ais-infra-common/template.yaml
+++ b/ais-infra-common/template.yaml
@@ -46,7 +46,7 @@ Resources:
     Properties:
       Name: "dynatrace-api-token"
       Description: "Dynatrace API token"
-      SecretString: "dt0c01.ESVFDCGJZEL6W7WUTCGKZAQN.QUFK5TZVRP3RNV4AAANE4MYXZIXVXWGRG2BHHU3WONNNM5EQERYZFKXFMQFGCGOJ" # uses the default aws/secretsmanager key to encrypt the secret string
+      SecretString: "placeholder-value" # uses the default aws/secretsmanager key to encrypt the secret string
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue


### PR DESCRIPTION
### What ? 

Added an ais-Infra-common template that includes Dynatrace api token with placeholder value to be deployed to Account Interventions Service Integration and Production accounts to set up pipeline metrics 
https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3660317070/How+to+add+secure+pipelines+metrics+to+Dynatrace 
