### PR TITLE
ATB-1220 | Create a infra-common template for Dynatrace api token as a Placeholder value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+---
+default_stages: [ commit ]
+
+repos:
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: detect-private-key
+      - id: detect-aws-credentials
+        args: [ --allow-missing-credentials ]
+      - id: mixed-line-ending
+      - id: check-merge-conflict
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.4.2
+    hooks:
+      - id: remove-tabs
+      - id: remove-crlf
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]
+
+#  - repo: https://github.com/bridgecrewio/checkov.git
+#    rev: '2.2.320'
+#    hooks:
+#      - id: checkov
+#        args: [ '--framework', 'cloudformation', '--quiet' ]
+#        files: ^(?!\..*).*/template\.(yml|yaml)$
+  - repo: https://github.com/aws-cloudformation/cfn-lint
+    rev: v0.72.10  # The version of cfn-lint to use
+    hooks:
+      - id: cfn-lint
+        files: ^(?!\..*).*/template\.(json|yml|yaml)$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,109 @@
+{
+  "version": "1.3.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2023-01-31T22:20:43Z"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # ais-infra
+
+This repo includes the following CloudFormation templates to be manually deployed.
+
+- [ais-infra-alerting]
+- [ais-infra-common]
+
+### Setup Pre-Commit
+Ensure pre-commit is enabled at the root of the directory
+```cd ais-infra ``` and apply the following command
+```shell
+$ pre-commit install -f
+```

--- a/ais-infra-common/README.md
+++ b/ais-infra-common/README.md
@@ -1,0 +1,44 @@
+# Account Interventions Service - AIS Infra Common
+
+## Intro
+Externalise values referenced across multiple CloudFormation Stacks.
+This prevents having to individually update each reference of a single value across multiple Stacks.
+Values will instead resolve as SSM parameters or Secrets acting as the single source of truth.
+
+## Prerequisites
+Export credentials for the AWS account where you want to deploy the application.
+You can use the following command to export credentials into your shell:
+```bash
+eval $(gds aws di-id-reuse-core-<environment>-admin -e)
+```
+Replace `<environment>` with the environment you are deploying into.
+Allowed values are `dev`, `build`, `staging`.
+
+Whereas to deploy to `integration` and  `production` you'd need to Login into the Account Interventions Service AWS accounts using sso
+
+`Integration`:
+```bash
+aws sso login --profile di-account-intervention-admin-217747075921
+```
+`Production`:
+```bash
+aws sso login --profile di-account-intervention-admin-324281879537
+```
+
+## How to Deploy
+To deploy this SAM template, follow these steps:
+1. Navigate to the `ais-infra-common` directory
+2. Build the SAM application:
+```bash
+sam build
+```
+3. Deploy the application to your AWS account:
+```bash
+sam deploy --guided
+```
+The `--guided` flag will prompt you to input the necessary parameters for the deployment, such as the stack name, region, and environment.
+
+After the deployment is complete, you can check the CloudFormation stack status in the AWS Management Console or by using the AWS CLI:
+```bash
+aws cloudformation describe-stacks --stack-name ais-infra-common --region eu-west-2
+```

--- a/ais-infra-common/samconfig.toml
+++ b/ais-infra-common/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "ais-infra-common"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-44r43ey3knwx"
+s3_prefix = "ais-infra-common"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+image_repositories = []
+parameter_overrides = "Environment=\"dev\""

--- a/ais-infra-common/template.yaml
+++ b/ais-infra-common/template.yaml
@@ -1,0 +1,62 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: >
+  Externalises values referenced across multiple CloudFormation Stacks.
+  This prevents having to individually update each reference of a single value across multiple stacks or resources.
+  Values will instead resolve as SSM parameters or Secrets acting as the single source of truth.
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    Default: dev
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  ProductTagValue:
+    Description: Value for the Product Tag
+    Type: String
+    Default: GOV.UK One Login
+  SystemTagValue:
+    Description: Value for the System Tag
+    Type: String
+    Default: Account Interventions Service
+  OwnerTagValue:
+    Description: Value for the Owner Tag
+    Type: String
+    Default: PLACEHOLDER
+  SourceTagValue:
+    Description: Value for the Source Tag
+    Type: String
+    Default: govuk-one-login/ais-infra/ais-infra-common/template.yaml
+
+Resources:
+
+  ###########
+  # SECRETS #
+  ###########
+
+  # see https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3660317070/How+to+add+secure+pipelines+metrics+to+Dynatrace
+  DynatraceApiToken:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: "dynatrace-api-token"
+      Description: "Dynatrace API token"
+      SecretString: "placeholder-value" #pragma: allowlist secret uses the default aws/secretsmanager key to encrypt the secret string
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynatraceApiToken"
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue


### PR DESCRIPTION
### What 

Created an infra-common template for Dynatrace api token as a Placeholder value be deployed to Account Interventions Service Integration and Production accounts be able to set up pipeline metrics 
https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3660317070/How+to+add+secure+pipelines+metrics+to+Dynatrace

Added pre-commit config file and .secrets.baseline to allow enable pre-commit on the repo. 

_Note: checkov currently uncommented out due to coming up with CKV_AWS_149 error which may not be required_ 