### PR TITLE
ATB-1246 | Set up custom namespace metrics to be sent to Dynatrace

### DIFF
--- a/ais-dynatrace-metrics/README.md
+++ b/ais-dynatrace-metrics/README.md
@@ -7,6 +7,14 @@ integration with CloudWatch Metric Streams to ingest AWS metrics for Account Int
 This Stack is to be deployed manually once per account/environment.
 
 ## Prerequisites
+
+#### ⚠️ Task to be carried out prior to deployment ⚠️
+
+- [ ] Deploy `ais-infra-common` template first
+- [ ] Manually update the Secret DynatraceApiKey to the provided value by https://gds.slack.com/archives/C04UF0B02NR
+
+❗Once these steps have been taken you can deploy this stack following the instructions below
+
 Export credentials for the AWS account where you want to deploy the application.
 You can use the following command to export credentials into your shell:
 ```bash

--- a/ais-dynatrace-metrics/README.md
+++ b/ais-dynatrace-metrics/README.md
@@ -43,3 +43,4 @@ After the deployment is complete, you can check the CloudFormation stack status 
 ```bash
 aws cloudformation describe-stacks --stack-name ais-dynatrace-metrics --region eu-west-2
 ```
+Note: Make sure you have deployed ais-infra-common stack first and updated the Secrets PLACEHOLDER values prior to deploying this stack.

--- a/ais-dynatrace-metrics/README.md
+++ b/ais-dynatrace-metrics/README.md
@@ -1,8 +1,10 @@
-# Account Interventions Service - AIS Infra Common
+# Account Interventions Service - Dynatrace Metrics
 
 ## Intro
+The SAM template creates our Dynatrace Metrics Stack which sets up the infrastructure required for Dynatrace
+integration with CloudWatch Metric Streams to ingest AWS metrics for Account Interventions Service.
 
-This stack contains AWS Secrets used for Dynatrace.
+This Stack is to be deployed manually once per account/environment.
 
 ## Prerequisites
 Export credentials for the AWS account where you want to deploy the application.
@@ -11,7 +13,7 @@ You can use the following command to export credentials into your shell:
 eval $(gds aws di-id-reuse-core-<environment>-admin -e)
 ```
 Replace `<environment>` with the environment you are deploying into.
-Allowed values are `dev`, `build`, `staging`.
+Allowed values are `dev`, `build`,and `staging` .
 
 Whereas to deploy to `integration` and  `production` you'd need to Login into the Account Interventions Service AWS accounts using sso
 
@@ -26,7 +28,7 @@ aws sso login --profile di-account-intervention-admin-324281879537
 
 ## How to Deploy
 To deploy this SAM template, follow these steps:
-1. Navigate to the `ais-infra-common` directory
+1. Navigate to the `ais-dynatrace-metrics` directory
 2. Build the SAM application:
 ```bash
 sam build
@@ -39,5 +41,5 @@ The `--guided` flag will prompt you to input the necessary parameters for the de
 
 After the deployment is complete, you can check the CloudFormation stack status in the AWS Management Console or by using the AWS CLI:
 ```bash
-aws cloudformation describe-stacks --stack-name ais-infra-common --region eu-west-2
+aws cloudformation describe-stacks --stack-name ais-dynatrace-metrics --region eu-west-2
 ```

--- a/ais-dynatrace-metrics/samconfig.toml
+++ b/ais-dynatrace-metrics/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "ais-dynatrace-metrics"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-44r43ey3knwx"
+s3_prefix = "ais-dynatrace-metrics"
+region = "eu-west-2"
+capabilities = "CAPABILITY_NAMED_IAM"
+image_repositories = []
+parameter_overrides = "Environment=\"dev\""

--- a/ais-dynatrace-metrics/template.yaml
+++ b/ais-dynatrace-metrics/template.yaml
@@ -1,0 +1,300 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: >
+  Infrastructure required for Dynatrace integration with CloudWatch Metric Streams to ingest
+  AWS metrics for VC Storage.
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    Default: dev
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  FirehoseHttpDeliveryEndpoint:
+    Description: URL to which Firehose will deliver stream
+    Type: String
+    Default: 'https://aws.cloud.dynatrace.com/metrics'
+  InfraCommonStackName:
+    Description: The name of the Infra Common stack
+    Type: String
+    Default: infra-common
+  ProductTagValue:
+    Description: Value for the Product Tag
+    Type: String
+    Default: GOV.UK One Login
+  SystemTagValue:
+    Description: Value for the System Tag
+    Type: String
+    Default: Account Interventions Service
+  OwnerTagValue:
+    Description: Value for the Owner Tag
+    Type: String
+    Default: PLACEHOLDER
+  SourceTagValue:
+    Description: Value for the Source Tag
+    Type: String
+    Default: govuk-one-login/ais-infra/ais-dynatrace-metrics/template.yaml
+
+Conditions:
+  IsNonProd: !Or [ !Equals [ !Ref Environment, dev ], !Equals [ !Ref Environment, build ],!Equals [ !Ref Environment, staging ]]
+
+Resources:
+
+  ###########
+  # DYNATRACE #
+  ###########
+
+  FirehoseMetricStreams:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamType: DirectPut
+      HttpEndpointDestinationConfiguration:
+        BufferingHints:
+          IntervalInSeconds: 60
+          SizeInMBs: 3
+        EndpointConfiguration:
+          AccessKey: !Sub "{{resolve:secretsmanager:/${InfraCommonStackName}/Dynatrace/Metric/Api/Key}}"
+          Name: Dynatrace delivery endpoint
+          Url: !Ref FirehoseHttpDeliveryEndpoint
+        RequestConfiguration:
+          CommonAttributes:
+            - AttributeName: dt-url
+              AttributeValue: !If
+                - IsNonProd
+                - 'https://khw46367.live.dynatrace.com'
+                - 'https://bhe21058.live.dynatrace.com'
+            - AttributeName: require-valid-certificate
+              AttributeValue: true
+          ContentEncoding: GZIP
+        RetryOptions:
+          DurationInSeconds: 900
+        S3BackupMode: FailedDataOnly
+        S3Configuration:
+          BucketARN: !GetAtt FailedDataBucket.Arn
+          RoleARN: !GetAtt FailedDataBucketRole.Arn
+      DeliveryStreamEncryptionConfigurationInput:
+        KeyARN: !GetAtt DynatraceKmsKey.Arn
+        KeyType: CUSTOMER_MANAGED_CMK
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  FailedDataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Join
+        - "-"
+        - - !Ref AWS::StackName
+          - faileddatabucket
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - "-"
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - /
+                          - Ref: AWS::StackId
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 30
+            Status: Enabled
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              KMSMasterKeyID: !GetAtt DynatraceKmsKey.Arn
+              SSEAlgorithm: "aws:kms"
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  FailedDataBucketPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref FailedDataBucketRole
+      PolicyName: !Sub "${AWS::StackName}-FailedDataBucketPolicy"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 's3:AbortMultipartUpload'
+              - 's3:GetBucketLocation'
+              - 's3:GetObject'
+              - 's3:ListBucket'
+              - 's3:ListBucketMultipartUploads'
+              - 's3:PutObject'
+            Resource:
+              - !GetAtt FailedDataBucket.Arn
+              - !Sub "${FailedDataBucket.Arn}/*"
+          - Effect: Allow
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey"
+            Resource:
+              - !GetAtt DynatraceKmsKey.Arn
+
+  FailedDataBucketRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': !Ref 'AWS::AccountId'
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  DynatraceKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: AWS KMS key for encrypting the data stored within our Failed Data Bucket for Dynatrace
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: "s3.amazonaws.com"
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+            Resource: "*"
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Sub "arn:aws:s3:::${AWS::StackName}-FailedDataBucket"
+          - Effect: Allow
+            Principal:
+              Service: "firehose.amazonaws.com"
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey*"
+            Resource: "*"
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynatraceKmsKey"
+
+  DynatraceKmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}-DynatraceKmsKey"
+      TargetKeyId: !GetAtt DynatraceKmsKey.Arn
+
+  MetricStreamsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - streams.metrics.cloudwatch.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'firehose:PutRecord'
+                  - 'firehose:PutRecordBatch'
+                Resource: !GetAtt FirehoseMetricStreams.Arn
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  MetricStream:
+    Type: AWS::CloudWatch::MetricStream
+    Properties:
+      FirehoseArn: !GetAtt FirehoseMetricStreams.Arn
+      RoleArn: !GetAtt MetricStreamsRole.Arn
+      OutputFormat: 'opentelemetry0.7'
+      IncludeFilters:
+        - Namespace: !Ref SystemTagValue
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue

--- a/ais-dynatrace-metrics/template.yaml
+++ b/ais-dynatrace-metrics/template.yaml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Description: >
   Infrastructure required for Dynatrace integration with CloudWatch Metric Streams to ingest
-  AWS metrics for VC Storage.
+  AWS metrics for Account Interventions Service.
 
 Parameters:
   Environment:

--- a/ais-infra-common/README.md
+++ b/ais-infra-common/README.md
@@ -41,3 +41,7 @@ After the deployment is complete, you can check the CloudFormation stack status 
 ```bash
 aws cloudformation describe-stacks --stack-name ais-infra-common --region eu-west-2
 ```
+#### ⚠️ Once this stack has been deployed, manually set the value of the secrets in AWS Console, values to be provided by - https://gds.slack.com/archives/C04UF0B02NR
+This step must be done prior to progressing to deploying the `ais-dynatrace-metrics`  and `ais-main` stack.
+
+#### ❗If the Secret values are changed both `ais-dynatrace-metrics`  and `ais-main` stack need to be redeployed so that the new values are used instead.

--- a/ais-infra-common/template.yaml
+++ b/ais-infra-common/template.yaml
@@ -2,9 +2,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
 Description: >
-  Externalises values referenced across multiple CloudFormation Stacks.
-  This prevents having to individually update each reference of a single value across multiple stacks or resources.
-  Values will instead resolve as SSM parameters or Secrets acting as the single source of truth.
+  This stack contains AWS Secrets used for Dynatrace.
 
 Parameters:
   Environment:
@@ -44,7 +42,7 @@ Resources:
   DynatraceApiToken:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: "dynatrace-api-token"
+      Name: !Sub "/${AWS::StackName}/Dynatrace/Api/Token"
       Description: "Dynatrace API token"
       SecretString: "placeholder-value" #pragma: allowlist secret uses the default aws/secretsmanager key to encrypt the secret string
       Tags:
@@ -56,6 +54,26 @@ Resources:
           Value: !Ref Environment
         - Key: Name
           Value: !Sub "${AWS::StackName}-DynatraceApiToken"
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  DynatraceApiKey:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "/${AWS::StackName}/Dynatrace/Metric/Api/Key"
+      Description: "Dynatrace Api Key for Namespace Metrics"
+      SecretString: "placeholder-value" # pragma: allowlist secret  uses the default aws/secretsmanager key to encrypt the secret string
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynatraceApiKey"
         - Key: Owner
           Value: !Ref OwnerTagValue
         - Key: Source


### PR DESCRIPTION
### What ?

Creating a CloudFormation template to deploy resources that will enable the Dynatrace integration with Amazon CloudWatch Metric Streams to ingest AWS metrics for the custom metric namespace Account Interventions Service .

### Why? 

To allow us to view our custom Account Interventions Service metrics in Dynatrace. 

### Testing: 
![Screenshot 2024-01-05 at 15 55 11](https://github.com/govuk-one-login/ais-infra/assets/116737136/7312a92f-d204-4536-81cc-ea3e0ace08b9)

Notes:

- Account Interventions Service custom metrics will be appear once the main pipeline runs.
- To be deployed all the way to Production, however, must note that will need to generate a Dynatrace Api Key (Joe Roberts) specifically for Production to be added as the value for DynatraceApiKey secret. 


