### PR TITLE
ATB-1402 | Small Parameter change to Dynatrace template

### DIFF
--- a/ais-dynatrace-metrics/template.yaml
+++ b/ais-dynatrace-metrics/template.yaml
@@ -23,7 +23,7 @@ Parameters:
   InfraCommonStackName:
     Description: The name of the Infra Common stack
     Type: String
-    Default: infra-common
+    Default: ais-infra-common
   ProductTagValue:
     Description: Value for the Product Tag
     Type: String


### PR DESCRIPTION
### What? 

A small Parameter change to Dynatrace template from referencing` infra-common` to `ais-infra-common ` as default

###  Why? 
 To stay consistent 