### PR TITLE
ATB-1452 | Create IAM Policy for defining appropriate permissions

### DIFF
--- a/ais-iam-permissions/samconfig.toml
+++ b/ais-iam-permissions/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "ais-iam-permissions"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-44r43ey3knwx"
+s3_prefix = "ais-iam-permissions"
+region = "eu-west-2"
+capabilities = "CAPABILITY_NAMED_IAM"
+image_repositories = []
+parameter_overrides = "Environment=\"dev\""

--- a/ais-iam-permissions/samconfig.toml
+++ b/ais-iam-permissions/samconfig.toml
@@ -8,4 +8,4 @@ s3_prefix = "ais-iam-permissions"
 region = "eu-west-2"
 capabilities = "CAPABILITY_NAMED_IAM"
 image_repositories = []
-parameter_overrides = "Environment=\"dev\""
+parameter_overrides = "Environment=\"staging\""

--- a/ais-iam-permissions/template.yaml
+++ b/ais-iam-permissions/template.yaml
@@ -1,0 +1,87 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: >
+  This template contains IAM permissions for access for Pen testing role.
+
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    Default: staging
+    AllowedValues:
+      - "staging"
+
+Conditions:
+  AllowPenTesterAccess: !Equals [!Ref Environment, staging]
+
+Resources:
+
+  AllowUserSelfManagement:
+    Condition: AllowPenTesterAccess
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: "AllowUserSelfManagement"
+      Description: Pen tester Policy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowViewAccountInfo
+            Effect: Allow
+            Action:
+              - "iam:GetAccountPasswordPolicy"
+              - "iam:GetAccountSummary"
+              - "iam:ListVirtualMFADevices"
+            Resource: "*"
+          - Sid: AllowManageOwnVirtualMFADevice
+            Effect: Allow
+            Action:
+              - "iam:CreateVirtualMFADevice"
+            Resource: "arn:aws:iam::*:mfa/*"
+          - Sid: AllowManageOwnUserMFA
+            Effect: Allow
+            Action:
+              - "iam:DeactivateMFADevice"
+              - "iam:EnableMFADevice"
+              - "iam:GetUser"
+              - "iam:ListMFADevices"
+              - "iam:ResyncMFADevice"
+            Resource: "arn:aws:iam::*:user/${aws:username}"
+          - Sid: AllowManageOwnPasswords
+            Effect: Allow
+            Action:
+              - "iam:ChangePassword"
+              - "iam:GetUser"
+            Resource: "arn:aws:iam::*:user/${aws:username}"
+          - Sid: AllowManageOwnAccessKeys
+            Effect: Allow
+            Action:
+              - "iam:CreateAccessKey"
+              - "iam:DeleteAccessKey"
+              - "iam:ListAccessKeys"
+              - "iam:UpdateAccessKey"
+              - "iam:GetAccessKeyLastUsed"
+            Resource: "arn:aws:iam::*:user/${aws:username}"
+          - Sid: AllowManageOwnSSHPublicKeys
+            Effect: Allow
+            Action:
+              - "iam:DeleteSSHPublicKey"
+              - "iam:GetSSHPublicKey"
+              - "iam:ListSSHPublicKeys"
+              - "iam:UpdateSSHPublicKey"
+              - "iam:UploadSSHPublicKey"
+            Resource: "arn:aws:iam::*:user/${aws:username}"
+          - Sid: DenyAllExceptListedIfNoMFA
+            Effect: Deny
+            NotAction:
+              - "iam:CreateVirtualMFADevice"
+              - "iam:EnableMFADevice"
+              - "iam:GetUser"
+              - "iam:ListMFADevices"
+              - "iam:ListVirtualMFADevices"
+              - "iam:ResyncMFADevice"
+              - "sts:GetSessionToken"
+            Resource: "*"
+            Condition:
+              BoolIfExists:
+                aws:MultiFactorAuthPresent: false


### PR DESCRIPTION
### What? 
Created an IAM policy named ‘AllowUserSelfManagement’ to grant pen tester access to AIS Account in Staging. 

### Why? 
Preparing to onboard the Pen Testing team into our AIS Staging Account. 