### PR TITLE
ATB-1518| Replace OwnerTagValue to team contact email

### DIFF
--- a/ais-dynatrace-metrics/template.yaml
+++ b/ais-dynatrace-metrics/template.yaml
@@ -35,7 +35,7 @@ Parameters:
   OwnerTagValue:
     Description: Value for the Owner Tag
     Type: String
-    Default: PLACEHOLDER
+    Default: interventions@digital.cabinet-office.gov.uk
   SourceTagValue:
     Description: Value for the Source Tag
     Type: String

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -21,7 +21,7 @@ Parameters:
   OwnerTagValue:
     Description: Value for the Owner Tag
     Type: String
-    Default: PLACEHOLDER
+    Default: interventions@digital.cabinet-office.gov.uk
   SourceTagValue:
     Description: Value for the Source Tag
     Type: String
@@ -70,7 +70,6 @@ Conditions:
           - !Ref SubscriptionEndpoint
           - "none"
   IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ] ]
-  IsInternal: !Or [ !Equals [ !Ref Environment, dev ], !Equals [ !Ref Environment, build ],!Equals [ !Ref Environment, staging ] ]
   IsDeployServiceLinkedRoles:
     Fn::Equals:
       - !Ref InitialNotificationStack

--- a/ais-infra-common/template.yaml
+++ b/ais-infra-common/template.yaml
@@ -26,7 +26,7 @@ Parameters:
   OwnerTagValue:
     Description: Value for the Owner Tag
     Type: String
-    Default: PLACEHOLDER
+    Default: interventions@digital.cabinet-office.gov.uk
   SourceTagValue:
     Description: Value for the Source Tag
     Type: String


### PR DESCRIPTION
### What? 
Replaced OwnerTagValue to team contact email to > [[interventions@digital.cabinet-office.gov.uk](mailto:interventions@digital.cabinet-office.gov.uk)]

### Why? 
Team contact email has now been created

Also removed `IsInternal` condition from `ais-infra-alerting` template as it was not in use in the template 