### PR TITLE
ATB-1563 | Create new slack channel for prod alerts

### DIFF
--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -38,24 +38,6 @@ Parameters:
     Default: "T8GT9416G"
     AllowedPattern: "\\w+"
     ConstraintDescription: "must be an AWS Chatbot Slack workspace ID"
-  SlackChannelId:
-    Description: >
-      The ID of the Slack channel where alert notification messages are posted from our non-prod environments.
-      This is taken from the channel details in Slack.
-      Default is the di-accounts-bravo-ais-notifications channel.
-    Type: String
-    Default: "C065MT3RKV4" # di-accounts-bravo-ais-notifications
-    AllowedPattern: "\\w+"
-    ConstraintDescription: "must be a Slack channel ID"
-  SlackChannelIdProd:
-    Description: >
-      The ID of the Slack channel where alert notification messages are posted for our Prod environment.
-      This is taken from the channel details in Slack.
-      Default is the di-accounts-bravo-ais-notifications-prod channel.
-    Type: String
-    Default: "C06R67X2EBC" # di-accounts-bravo-ais-notifications-prod
-    AllowedPattern: "\\w+"
-    ConstraintDescription: "must be a Slack channel ID"
   SubscriptionEndpoint:
     Description: >
       External API subscription endpoint i.e. PagerDuty events integration API
@@ -306,8 +288,8 @@ Resources:
       IamRoleArn: !GetAtt ChatbotRole.Arn
       SlackChannelId: !If
         - IsProd
-        - !Ref SlackChannelIdProd
-        - !Ref SlackChannelId
+        - C06R67X2EBC # di-accounts-bravo-ais-notifications-prod
+        - C065MT3RKV4 # di-accounts-bravo-ais-notifications
       SlackWorkspaceId: !Ref SlackWorkspaceId
       SnsTopicArns:
         - !Ref HighAlertNotificationTopic

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -40,11 +40,20 @@ Parameters:
     ConstraintDescription: "must be an AWS Chatbot Slack workspace ID"
   SlackChannelId:
     Description: >
-      The ID of the Slack channel where alert notification messages are posted.
+      The ID of the Slack channel where alert notification messages are posted from our non-prod environments.
       This is taken from the channel details in Slack.
       Default is the di-accounts-bravo-ais-notifications channel.
     Type: String
     Default: "C065MT3RKV4" # di-accounts-bravo-ais-notifications
+    AllowedPattern: "\\w+"
+    ConstraintDescription: "must be a Slack channel ID"
+  SlackChannelIdProd:
+    Description: >
+      The ID of the Slack channel where alert notification messages are posted for our Prod environment.
+      This is taken from the channel details in Slack.
+      Default is the di-accounts-bravo-ais-notifications-prod channel.
+    Type: String
+    Default: "C06R67X2EBC" # di-accounts-bravo-ais-notifications-prod
     AllowedPattern: "\\w+"
     ConstraintDescription: "must be a Slack channel ID"
   SubscriptionEndpoint:
@@ -69,7 +78,8 @@ Conditions:
       - Fn::Equals:
           - !Ref SubscriptionEndpoint
           - "none"
-  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ] ]
+  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
+  IsProd: !Equals [!Ref Environment, production]
   IsDeployServiceLinkedRoles:
     Fn::Equals:
       - !Ref InitialNotificationStack
@@ -294,7 +304,10 @@ Resources:
     Properties:
       ConfigurationName: !Sub "${AWS::StackName}-slack-notifications"
       IamRoleArn: !GetAtt ChatbotRole.Arn
-      SlackChannelId: !Ref SlackChannelId
+      SlackChannelId: !If
+        - IsProd
+        - !Ref SlackChannelIdProd
+        - !Ref SlackChannelId
       SlackWorkspaceId: !Ref SlackWorkspaceId
       SnsTopicArns:
         - !Ref HighAlertNotificationTopic


### PR DESCRIPTION
### What ?
Created a new slack channel where all our Prod alerts will appear > [Slack](https://gds.slack.com/archives/C06R67X2EBC ) 

### Why ?
We want to differentiate between our prod alerts and non-prod alerts in slack as it makes it easier to view 

### Test 
Tested in Dev by changing the condition 
<img width="565" alt="Screenshot 2024-03-25 at 15 36 54" src="https://github.com/govuk-one-login/ais-infra/assets/116737136/49fc341d-cef8-4cb6-8e52-8cbe56a79014">

