### PR TITLE
ATB-1524 | Adding in SubscriptionEndpoint URL

### DIFF
--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -38,13 +38,6 @@ Parameters:
     Default: "T8GT9416G"
     AllowedPattern: "\\w+"
     ConstraintDescription: "must be an AWS Chatbot Slack workspace ID"
-  SubscriptionEndpoint:
-    Description: >
-      External API subscription endpoint i.e. PagerDuty events integration API
-    Type: String
-    Default: "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
-    AllowedPattern: "(^https://.+)|(none)"
-    ConstraintDescription: "Must be a URL of format (https://.*) or leave as 'none'"
   InitialNotificationStack:
     Description: >
       (Optional) Is this the first notification stack to be created in this account?
@@ -55,11 +48,6 @@ Parameters:
       - "No"
 
 Conditions:
-  CreateSNSSubscription:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref SubscriptionEndpoint
-          - "none"
   IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
   IsProd: !Equals [!Ref Environment, production]
   IsDeployServiceLinkedRoles:
@@ -325,10 +313,12 @@ Resources:
   #
 
   AlertNotificationTopicSubscription:
-    Condition: CreateSNSSubscription
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Ref SubscriptionEndpoint
+      Endpoint: !If
+        - IsProd
+        - "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
+        - "none"
       Protocol: 'https'
       TopicArn: !Ref HighAlertNotificationTopic
 

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -48,8 +48,9 @@ Parameters:
       - "No"
 
 Conditions:
-  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
-  IsProd: !Equals [!Ref Environment, production]
+#  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
+  IsNotDevelopment: !Equals [!Ref Environment, dev]
+  IsProd: !Equals [!Ref Environment, dev]
   IsDeployServiceLinkedRoles:
     Fn::Equals:
       - !Ref InitialNotificationStack
@@ -316,7 +317,7 @@ Resources:
     Condition: IsProd
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
+      Endpoint: "https://www.bbc.co.uk"
       Protocol: 'https'
       TopicArn: !Ref HighAlertNotificationTopic
 

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -48,9 +48,8 @@ Parameters:
       - "No"
 
 Conditions:
-#  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
-  IsNotDevelopment: !Equals [!Ref Environment, dev]
-  IsProd: !Equals [!Ref Environment, dev]
+  IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
+  IsProd: !Equals [!Ref Environment, production]
   IsDeployServiceLinkedRoles:
     Fn::Equals:
       - !Ref InitialNotificationStack
@@ -317,7 +316,7 @@ Resources:
     Condition: IsProd
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: "https://www.bbc.co.uk"
+      Endpoint: "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
       Protocol: 'https'
       TopicArn: !Ref HighAlertNotificationTopic
 

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -313,12 +313,10 @@ Resources:
   #
 
   AlertNotificationTopicSubscription:
+    Condition: IsProd
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !If
-        - IsProd
-        - "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
-        - "none"
+      Endpoint: "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
       Protocol: 'https'
       TopicArn: !Ref HighAlertNotificationTopic
 

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -42,7 +42,7 @@ Parameters:
     Description: >
       External API subscription endpoint i.e. PagerDuty events integration API
     Type: String
-    Default: "none"
+    Default: "https://events.pagerduty.com/integration/96e06442f974460fd0dd0b45a26c8f52/enqueue"
     AllowedPattern: "(^https://.+)|(none)"
     ConstraintDescription: "Must be a URL of format (https://.*) or leave as 'none'"
   InitialNotificationStack:


### PR DESCRIPTION
### What? 

Adding in the Integration URL for Pager Duty into our template 

### Why? 

To set up Pager Duty Integration for Production (manual deployment)