### PR TITLE
FPAD-7747: Remove build notifications

### DIFF
--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -143,45 +143,6 @@ Resources:
               Service: cloudwatch.amazonaws.com
 
   #
-  # Pipeline Build SNS Topic
-  #
-
-  BuildNotificationTopic:
-    Type: AWS::SNS::Topic
-    Properties:
-      TopicName: !Sub "${AWS::StackName}-BuildNotificationTopic"
-      KmsMasterKeyId: !Ref NotificationTopicKey
-      Tags:
-        - Key: Name
-          Value: !Join
-            - "-"
-            - - !Ref AWS::StackName
-              - "BuildNotificationTopic"
-        - Key: Product
-          Value: !Ref ProductTagValue
-        - Key: System
-          Value: !Ref SystemTagValue
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: Owner
-          Value: !Ref OwnerTagValue
-        - Key: Source
-          Value: !Ref SourceTagValue
-
-  BuildNotificationTopicPolicy:
-    Type: AWS::SNS::TopicPolicy
-    Properties:
-      Topics:
-        - !Ref BuildNotificationTopic
-      PolicyDocument:
-        Statement:
-          - Action: "sns:Publish"
-            Effect: Allow
-            Resource: !Ref BuildNotificationTopic
-            Principal:
-              Service: codestar-notifications.amazonaws.com
-
-  #
   # Shared SNS KMS Key
   #
 
@@ -362,25 +323,3 @@ Resources:
         System: !Ref SystemTagValue
         Owner: !Ref OwnerTagValue
         Source: !Ref SourceTagValue
-
-  BuildNotificationTopicArnSSM:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The ARN of the Build Notification SNS Topic used for Alert actions
-      Name: !Sub "/${AWS::StackName}/SNS/BuildNotificationTopic/ARN"
-      Type: String
-      Value: !Ref BuildNotificationTopic
-      Tags:
-        Environment: !Ref Environment
-        Product: !Ref ProductTagValue
-        System: !Ref SystemTagValue
-        Owner: !Ref OwnerTagValue
-        Source: !Ref SourceTagValue
-
-Outputs:
-  BuildNotificationTopicArn:
-    Description: >
-      The ARN of the SNS topic that receives CodePipeline build notifications that gets sent to Slack.
-    Value: !Ref BuildNotificationTopic
-    Export:
-      Name: !Sub "${AWS::StackName}-BuildNotificationTopicArn"

--- a/ais-infra-alerting/template.yaml
+++ b/ais-infra-alerting/template.yaml
@@ -55,13 +55,6 @@ Mappings:
       staging: 'C065MT3RKV4' #di-one-login-home-ais-nonprod
       integration: 'C065MT3RKV4' #di-one-login-home-ais-nonprod
       production: 'C06R67X2EBC' #di-one-login-home-ais-prod
-  BuildNotificationSlackChannel:
-    Environment:
-      dev: 'C0ANYQQD622' #di-fraud-ais-build-notifications
-      build: 'C0ANYQQD622' #di-fraud-ais-build-notifications
-      staging: 'C0ANYQQD622' #di-fraud-ais-build-notifications
-      integration: 'C0ANYQQD622' #di-fraud-ais-build-notifications
-      production: 'C0ANYQQD622' #di-fraud-ais-build-notifications
 
 Conditions:
   IsNotDevelopment: !Not [ !Equals [ !Ref Environment, dev ]]
@@ -301,17 +294,6 @@ Resources:
       SnsTopicArns:
         - !Ref HighAlertNotificationTopic
         - !Ref LowAlertNotificationTopic
-
-  BuildNotificationsChatbotChannelConfiguration:
-    Condition: IsNotDevelopment
-    Type: AWS::Chatbot::SlackChannelConfiguration
-    Properties:
-      ConfigurationName: !Sub "${AWS::StackName}-slack-notifications"
-      IamRoleArn: !GetAtt ChatbotRole.Arn
-      SlackChannelId: !FindInMap [BuildNotificationSlackChannel, Environment, !Ref Environment]
-      SlackWorkspaceId: !Ref SlackWorkspaceId
-      SnsTopicArns:
-        - !Ref BuildNotificationTopic
 
   CodeStarNotificationsServiceLinkedRole:
     Condition: IsServiceLinkRoleRequired


### PR DESCRIPTION
## What

Remove build notifications from ais-infra-alerting stack.

## Why

The dev platform supported `build-notifications` stack has now been deployed into all environments.